### PR TITLE
feat: Added searxng preferences field and functionality to settings page

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,7 @@ const defaultSettings = {
     use_function_tool: false,
     regex: [],
     searxng_url: '',
+    searxng_preferences: '',
 };
 
 /**
@@ -833,7 +834,7 @@ async function doSearxngQuery(query) {
     const result = await fetch('/api/search/searxng', {
         method: 'POST',
         headers: getRequestHeaders(),
-        body: JSON.stringify({ query, baseUrl: extension_settings.websearch.searxng_url }),
+        body: JSON.stringify({ query, baseUrl: extension_settings.websearch.searxng_url, preferences: extension_settings.websearch.searxng_preferences }),
     });
 
     if (!result.ok) {
@@ -1359,6 +1360,12 @@ jQuery(async () => {
     $('#websearch_searxng_url').val(extension_settings.websearch.searxng_url);
     $('#websearch_searxng_url').on('input', () => {
         extension_settings.websearch.searxng_url = String($('#websearch_searxng_url').val());
+        saveSettingsDebounced();
+    });
+
+    $('#websearch_searxng_preferences').val(extension_settings.websearch.searxng_preferences);
+    $('#websearch_searxng_preferences').on('input', () => {
+        extension_settings.websearch.searxng_preferences = String($('#websearch_searxng_preferences').val());
         saveSettingsDebounced();
     });
 

--- a/settings.html
+++ b/settings.html
@@ -39,6 +39,8 @@
                     </div>
                     <label for="websearch_searxng_url">Base URL</label>
                     <input type="text" class="text_pole" id="websearch_searxng_url" value="">
+                    <label for="websearch_searxng_preferences">SearXNG preferences string</label>
+                    <input type="text" class="text_pole" id="websearch_searxng_preferences" value="">
                 </div>
                 <div id="websearch_extras_settings">
                     <label for="websearch_extras_engine">Engine</label>


### PR DESCRIPTION
SearXNG has a feature to allow preferences to be saved as a sting and included in queries. This string can be appended to the query with `preferences=`.
Many instances only have google as the default, and this often gets temporarily shut down due to over-usage, so being able to set the preferences to have searxng use other engines, and save this in the preferences string, is an important feature.

Simple change, sister change in the SillyTavern Backend:
https://github.com/SillyTavern/SillyTavern/pull/3068